### PR TITLE
Specify color for all debug text, fix typo for monospace font

### DIFF
--- a/debug.css
+++ b/debug.css
@@ -380,7 +380,6 @@ div.debug div.results header{
 	font-weight: bold;
 	margin-right: 1px;
 	margin-top: -1px;
-	text-transform: capitalize;
 }
 div.debug div.results header.section{
 font-size: 15px;

--- a/debug.css
+++ b/debug.css
@@ -18,6 +18,7 @@ div.debug *{
 	margin:0;
 	padding:0;
 	border: 0;
+	color:#444;
 }
 div.debug div{
 	clear:both;
@@ -156,7 +157,7 @@ div.customTags td{
 div.debug div.variables *,
 div.debug div.timers *,
 div.debug div.clientHeaders{
-	ont-family:monospace !important;
+	font-family:monospace !important;
 	color:#444444;
 	font-size: 10px;
 }


### PR DESCRIPTION
Lasso9 error page gives unreadable debug output due to white text color from parent page, this fixes that issue.
